### PR TITLE
Fix show streaming episode lookup

### DIFF
--- a/backend/routes/stream.py
+++ b/backend/routes/stream.py
@@ -62,7 +62,7 @@ def stream_show_segment(show_id, episode_id, segment):
             cursor.execute("""
                 SELECT filepath
                 FROM show_episodes
-                WHERE show_id = %s AND episode_number = %s
+                WHERE show_id = %s AND id = %s
             """, (show_id, episode_id))
             
             result = cursor.fetchone()

--- a/frontend/anieflix/src/pages/ShowDetail.jsx
+++ b/frontend/anieflix/src/pages/ShowDetail.jsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import axios from 'axios'
+import axios from '../api/axios'
 import { Play, Heart, Plus, Share2, MessageCircle } from 'lucide-react'
 
 export default function ShowDetail() {
@@ -30,7 +30,14 @@ export default function ShowDetail() {
         >
           <div className="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-transparent" />
           <div className="absolute bottom-6 left-6">
-            <button className="bg-yellow-400 hover:bg-yellow-500 text-black text-lg px-6 py-3 rounded-full font-semibold flex items-center gap-2 shadow-lg transition">
+            <button
+              onClick={() => {
+                if (show.episodes?.length) {
+                  navigate(`/shows/${id}/watch/${show.episodes[0].id}`)
+                }
+              }}
+              className="bg-yellow-400 hover:bg-yellow-500 text-black text-lg px-6 py-3 rounded-full font-semibold flex items-center gap-2 shadow-lg transition"
+            >
               <Play size={22} /> Xem Ngay
             </button>
           </div>


### PR DESCRIPTION
## Summary
- ensure show segment streaming looks up episodes by ID
- connect show detail page to backend API and start playback from first episode

## Testing
- `python -m py_compile backend/routes/stream.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847afd4a56c832e918189a92b12c8ce