### PR TITLE
Add hover-based movie preview

### DIFF
--- a/frontend/anieflix/src/components/MovieHoverCard.jsx
+++ b/frontend/anieflix/src/components/MovieHoverCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function MovieHoverCard({ movie }) {
+  if (!movie) return null
+  return (
+    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 bg-[#141414] text-white rounded-lg shadow-lg p-3 hidden group-hover:block z-20">
+      <div className="w-full h-32 bg-cover bg-center rounded" style={{ backgroundImage: movie.backdrop_path ? `url(${movie.backdrop_path})` : `url('https://via.placeholder.com/300x169?text=No+Image')` }} />
+      <h4 className="mt-2 font-semibold text-sm truncate">{movie.title}</h4>
+      {movie.overview && <p className="text-xs text-gray-300 mt-1 line-clamp-3">{movie.overview}</p>}
+    </div>
+  )
+}

--- a/frontend/anieflix/src/components/SlideRow.jsx
+++ b/frontend/anieflix/src/components/SlideRow.jsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import MovieHoverCard from './MovieHoverCard'
 
 export default function SlideRow({ title, items, onItemClick, viewAllUrl }) {
   const scrollRef = useRef()
@@ -43,8 +44,9 @@ export default function SlideRow({ title, items, onItemClick, viewAllUrl }) {
             <div
               key={item.id}
               onClick={() => onItemClick(item)}
-              className="min-w-[180px] max-w-[200px] cursor-pointer group"
+              className="relative min-w-[180px] max-w-[200px] cursor-pointer group"
             >
+              <MovieHoverCard movie={item} />
               <div className="relative aspect-[16/9] rounded-xl overflow-hidden mb-2">
                 <img
                   src={item.poster_path || 'https://via.placeholder.com/300x450?text=No+Image'}


### PR DESCRIPTION
## Summary
- show a small popup when hovering movie items
- make mini popup component

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f159d084832eb6496f88c6cdc1e4